### PR TITLE
Upgraded whatsapp/call buttons in map location list 

### DIFF
--- a/frontend/public/icons/phone-icon.svg
+++ b/frontend/public/icons/phone-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="256" height="256" viewBox="0 0 256 256" xml:space="preserve">
+
+<defs>
+</defs>
+<g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(13.6466926070039 13.646692607003871) scale(2.53 2.53)" >
+	<circle cx="45" cy="45" r="45" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(28,127,205); fill-rule: nonzero; opacity: 1;" transform="  matrix(1 0 0 1 0 0) "/>
+	<path d="M 57.332 70.088 c -1.955 0.001 -4.074 -0.313 -6.32 -0.946 c -6.303 -1.777 -12.904 -5.885 -18.586 -11.568 c -5.682 -5.682 -9.79 -12.283 -11.568 -18.586 c -1.84 -6.528 -0.978 -11.999 2.429 -15.406 c 0.124 -0.124 0.25 -0.244 0.38 -0.36 c 0.033 -0.046 0.07 -0.09 0.112 -0.131 l 1.819 -1.819 c 0.877 -0.877 2.042 -1.36 3.282 -1.36 c 1.24 0 2.405 0.483 3.282 1.36 l 6.976 6.977 c 1.809 1.809 1.809 4.754 0 6.563 L 36.149 37.8 c -0.753 0.753 -0.753 1.979 0 2.732 L 49.468 53.85 c 0.729 0.729 2.002 0.729 2.732 0 l 2.988 -2.988 c 1.809 -1.808 4.755 -1.81 6.564 -0.001 l 6.977 6.977 c 0.876 0.876 1.359 2.042 1.359 3.281 s -0.483 2.405 -1.359 3.281 l -1.819 1.819 c -0.042 0.042 -0.087 0.08 -0.133 0.114 c -0.117 0.13 -0.236 0.256 -0.36 0.379 C 64.182 68.948 61.058 70.088 57.332 70.088 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round" />
+</g>
+</svg>

--- a/frontend/src/components/elements/LocationPreviewItem.tsx
+++ b/frontend/src/components/elements/LocationPreviewItem.tsx
@@ -1,12 +1,12 @@
 import AppChip from '@/components/elements/AppChip'
 import useStaticTranslation from '@/hooks/useStaticTranslation'
 import { renderLocationIcon } from '@/util/mapFunctions'
-import { generateWALink } from '@/util/whatsapp'
-import { Button, IconButton, Popover, Stack, Typography } from '@mui/material'
+import { Button, Popover, Stack, Typography } from '@mui/material'
 import type { Location } from 'LocationTypes'
 import Image from 'next/image'
-import WhatsAppIcon from 'public/icons/whatsapp.svg'
+
 import { MouseEvent, memo, useState } from 'react'
+import PhoneContactButton from './PhoneContactButton'
 
 type Props = { location: Location; onClick: (location: Location) => void; focusMap: (location: google.maps.LatLngLiteral) => void }
 
@@ -86,9 +86,16 @@ const LocationPreviewItem = ({ location, onClick, focusMap }: Props) => {
           onClick={handleClick}
           fullWidth={false}
         >
-          <Typography sx={{ width: '100%', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{`${t('street_short')} ${
-            location.FormattedAddress
-          }`}</Typography>
+          <Typography
+            sx={{
+              width: '100%',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {`${t('street_short')} ${location.FormattedAddress}`}
+          </Typography>
         </Button>
         {location.OpeningHours_c && (
           <>
@@ -136,11 +143,7 @@ const LocationPreviewItem = ({ location, onClick, focusMap }: Props) => {
           </>
         )}
       </Stack>
-      {location.WhatsappNumber_c && (
-        <IconButton disableRipple href={generateWALink(t('wa_default_text'), location.WhatsappNumber_c)} target="_blank">
-          <Image src={WhatsAppIcon} alt="whatsapp" width={30} height={30} />
-        </IconButton>
-      )}
+      <PhoneContactButton number={location.WhatsappNumber_c} messageText={t('wa_default_text')} />
     </Stack>
   )
 }

--- a/frontend/src/components/elements/PhoneContactButton.tsx
+++ b/frontend/src/components/elements/PhoneContactButton.tsx
@@ -1,0 +1,29 @@
+import { checkPhoneNumberType, generateWALink } from '@/util/whatsapp'
+import { IconButton, Tooltip } from '@mui/material'
+import Image from 'next/image'
+import PhoneIcon from 'public/icons/phone-icon.svg'
+import WhatsAppIcon from 'public/icons/whatsapp.svg'
+import { memo } from 'react'
+
+type Props = {
+  number: string | null | undefined
+  messageText: string
+}
+
+const PhoneContactButton = ({ number, messageText }: Props) => {
+  if (!number) return null
+  const cleanNumber = number.replace(/-|\s/g, '')
+  const numberType = checkPhoneNumberType(cleanNumber)
+  const isMobile = numberType === 'mobile'
+  const iconSize = isMobile ? 30 : 32
+
+  return (
+    <Tooltip title={number} placement="right" arrow>
+      <IconButton disableRipple href={isMobile ? generateWALink(messageText, cleanNumber) : `tel:${cleanNumber}`} target="_blank">
+        <Image src={isMobile ? WhatsAppIcon : PhoneIcon} alt={number} width={iconSize} height={iconSize} />
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+export default memo(PhoneContactButton)

--- a/frontend/src/util/whatsapp.ts
+++ b/frontend/src/util/whatsapp.ts
@@ -5,3 +5,21 @@ export const generateWALink = (message: string, number?: string) => {
   const phoneNumber = number || dfaultPhoneNumber
   return `${baseLink}/${phoneNumber}/?text=${encodeURIComponent(message)}`
 }
+
+type PhoneType = 'landline' | 'mobile' | null
+export const checkPhoneNumberType = (phoneNumber: string): PhoneType => {
+  // Check if it's a mobile phone number pattern
+  const isMobilePattern = /^(05[0-8])\d{7}$/.test(phoneNumber)
+  if (isMobilePattern) return 'mobile'
+
+  // Check if it's a landline phone number pattern
+  const isLandlinePattern = /^(02|03|04|08|09)\d{7}$/.test(phoneNumber)
+  if (isLandlinePattern) return 'landline'
+
+  //If not match pattern match based on length
+  if (phoneNumber.length === 9 && phoneNumber[0] === '0') return 'mobile'
+  if (phoneNumber.length === 10 && phoneNumber[0] === '0') return 'landline'
+
+  // If not a phone number
+  return null
+}


### PR DESCRIPTION
- Strips number of dashes and spaces
- Checks if mobile or landline numbers
- If mobile, show WA icon with link to message
- If landline show new Dialer icon with click to call
- Added tooltip on hover that shows the number (For desktop users)